### PR TITLE
fix location of txt output

### DIFF
--- a/chimera_stats/workflow.wdl
+++ b/chimera_stats/workflow.wdl
@@ -122,7 +122,7 @@ task runLiger2LiGerFromBam {
         ## tar some outputs
         mkdir -p ~{outprefix}.liger2liger_output
         mv liger2liger_output/*.png ~{outprefix}.liger2liger_output/
-        mv liger2liger_output/*.txt ~{outprefix}.liger2liger_output/
+        mv *.txt ~{outprefix}.liger2liger_output/
         tar czvf ~{outprefix}.liger2liger_output.tar.gz ~{outprefix}.liger2liger_output/
 	>>>
 


### PR DESCRIPTION
Output of `filter_chimeras_from_alignment -i reads.bam` isn't in `liger2liger_output`